### PR TITLE
Remove duplicate configuration entries in DefaultEngine.ini

### DIFF
--- a/LMIntegration/Config/DefaultEngine.ini
+++ b/LMIntegration/Config/DefaultEngine.ini
@@ -22,15 +22,11 @@ r.GenerateMeshDistanceFields=True
 r.DynamicGlobalIlluminationMethod=1
 r.Mobile.EnableNoPrecomputedLightingCSMShader=1
 r.DefaultFeature.AutoExposure.ExtendDefaultLuminanceRange=True
-r.DefaultFeature.AutoExposure.ExtendDefaultLuminanceRange=True
-r.DefaultFeature.AutoExposure.ExtendDefaultLuminanceRange=true
 
 r.Shadow.Virtual.Enable=1
 
 r.DefaultFeature.LocalExposure.HighlightContrastScale=0.8
-r.DefaultFeature.LocalExposure.HighlightContrastScale=0.8
 
-r.DefaultFeature.LocalExposure.ShadowContrastScale=0.8
 r.DefaultFeature.LocalExposure.ShadowContrastScale=0.8
 r.DefaultFeature.LightUnits=2
 r.AllowStaticLighting=False
@@ -50,7 +46,6 @@ r.RayTracing=True
 r.RayTracing.RayTracingProxies.ProjectEnabled=True
 
 [/Script/WindowsTargetPlatform.WindowsTargetSettings]
-DefaultGraphicsRHI=DefaultGraphicsRHI_DX12
 DefaultGraphicsRHI=DefaultGraphicsRHI_DX12
 -D3D12TargetedShaderFormats=PCD3D_SM5
 +D3D12TargetedShaderFormats=PCD3D_SM6


### PR DESCRIPTION
This change removes several duplicate configuration entries in `LMIntegration/Config/DefaultEngine.ini`. These entries were assigning the same value to the same key multiple times consecutively, which is redundant and can lead to confusion.

**What:** Removed duplicate lines for `DefaultGraphicsRHI`, `r.DefaultFeature.AutoExposure.ExtendDefaultLuminanceRange`, `r.DefaultFeature.LocalExposure.HighlightContrastScale`, and `r.DefaultFeature.LocalExposure.ShadowContrastScale`.
**Why:** Improves code health by removing redundancy, making the configuration file easier to read and maintain.
**Verification:** Manually verified the file content to ensure only one instance of each key remains and that the file structure is intact.
**Result:** A cleaner and more maintainable `DefaultEngine.ini` file.