### PR TITLE
[security] Disable insecure network configuration for Android File Server

### DIFF
--- a/LMIntegration/Config/DefaultEngine.ini
+++ b/LMIntegration/Config/DefaultEngine.ini
@@ -77,8 +77,8 @@ UIScaleRule=ShortestSide
 
 [/Script/AndroidFileServerEditor.AndroidFileServerRuntimeSettings]
 bEnablePlugin=True
-bAllowNetworkConnection=True
-SecurityToken=0B9962E14524DF203E34DBADDEBCD9EE
+bAllowNetworkConnection=False
+SecurityToken=
 bIncludeInShipping=False
 bAllowExternalStartInShipping=False
 bCompileAFSProject=False


### PR DESCRIPTION
This pull request fixes a security vulnerability in the Android File Server configuration within `DefaultEngine.ini`.

**What:** The vulnerability fixed is an insecure network configuration for the Android File Server.
**Risk:** `bAllowNetworkConnection=True` combined with a hardcoded `SecurityToken` allowed anyone on the same network to potentially access the file server on the Android device, leading to unauthorized file access or modification.
 **Solution:** The fix sets `bAllowNetworkConnection=False` to restrict connectivity to USB/ADB only and clears the hardcoded `SecurityToken` to follow security best practices.